### PR TITLE
Change minimum tenderPeriod duration to 1 day

### DIFF
--- a/openprocurement/auctions/appraisal/constants.py
+++ b/openprocurement/auctions/appraisal/constants.py
@@ -5,6 +5,7 @@ from openprocurement.auctions.core.constants import TZ
 
 DUTCH_PERIOD = timedelta(minutes=405)
 QUICK_DUTCH_PERIOD = timedelta(minutes=10)
+MIN_TENDER_PERIOD_DAYS_AMOUNT = 1
 
 TENDER_PERIOD_STATUSES = ['active.tendering', 'active.auction']
 NUMBER_OF_STAGES = 80   # from openprocurement.auction.appraisal.constants import DUTCH_ROUNDS as NUMBER_OF_STAGES

--- a/openprocurement/auctions/appraisal/models.py
+++ b/openprocurement/auctions/appraisal/models.py
@@ -301,6 +301,21 @@ class AppraisalAuction(BaseAuction):
         if self.tenderPeriod:
             self.rectificationPeriod = RectificationPeriod() if not self.rectificationPeriod else self.rectificationPeriod
             self.rectificationPeriod.startDate = self.tenderPeriod.startDate
+
+            # for a new type of procedure we should allow tenderPeriod of 1 day.
+            # In this case rectificationPeriod does not exist. But if rectificationPeriod does not exist
+            # procedure is editable. To make it unchangeable,
+            # we should create rectificationPeriod with startDate == endDate == tenderPeriod.startDate
+            five_working_days_after_start_date = calculate_business_date(
+                self.tenderPeriod.startDate,
+                timedelta(days=5),
+                None,
+                working_days=True
+            )
+            if self.tenderPeriod.endDate < five_working_days_after_start_date:
+                self.rectificationPeriod.endDate = self.rectificationPeriod.startDate
+                return self.rectificationPeriod
+
             self.rectificationPeriod.endDate = calculate_business_date(
                 self.tenderPeriod.endDate.astimezone(TZ),
                 -timedelta(days=5),

--- a/openprocurement/auctions/appraisal/models.py
+++ b/openprocurement/auctions/appraisal/models.py
@@ -69,6 +69,7 @@ from openprocurement.auctions.core.utils import (
 from openprocurement.auctions.appraisal.constants import (
     DUTCH_PERIOD,
     QUICK_DUTCH_PERIOD,
+    MIN_TENDER_PERIOD_DAYS_AMOUNT,
     NUMBER_OF_STAGES,
     AUCTION_STATUSES,
     CONTRACT_TYPES,
@@ -281,12 +282,12 @@ class AppraisalAuction(BaseAuction):
 
             min_end_date_limit = calculate_business_date(
                 value['startDate'],
-                timedelta(days=7),
+                timedelta(days=MIN_TENDER_PERIOD_DAYS_AMOUNT),
                 data,
                 working_days=True
             )
             if value['endDate'] < min_end_date_limit:
-                raise ValidationError(u"tenderPeriod should be at least 7 working days")
+                raise ValidationError(u"tenderPeriod should be at least {} working days".format(MIN_TENDER_PERIOD_DAYS_AMOUNT))
 
 
     @serializable(serialized_name="minimalStep", type=ModelType(Value))

--- a/openprocurement/auctions/appraisal/models.py
+++ b/openprocurement/auctions/appraisal/models.py
@@ -266,7 +266,9 @@ class AppraisalAuction(BaseAuction):
             role = 'concierge'
         else:
             role = 'edit_{}'.format(request.context.status)
-            if request.context.status == 'active.tendering' and get_now() < self.rectification_period.endDate:
+            rectification_period_exists = self.rectification_period.endDate is not None
+            rectification_period_not_finished = rectification_period_exists and get_now() < self.rectification_period.endDate
+            if request.context.status == 'active.tendering' and rectification_period_not_finished:
                 role += '_during_rectification_period'
         return role
 

--- a/openprocurement/auctions/appraisal/tests/blanks/tender_blanks.py
+++ b/openprocurement/auctions/appraisal/tests/blanks/tender_blanks.py
@@ -1482,6 +1482,7 @@ def patch_auction(self):
     )
     auction = response.json['data']
     dateModified = auction.pop('dateModified')
+    auction['rectificationPeriod'].pop('invalidationDate')
 
     response = self.app.patch_json('/auctions/{}?acc_token={}'.format(auction['id'], owner_token),
                                    {'data': {'status': 'cancelled'}})
@@ -1509,6 +1510,7 @@ def patch_auction(self):
     self.assertEqual(response.content_type, 'application/json')
     new_auction = response.json['data']
     new_auction.pop('dateModified')
+    new_auction['rectificationPeriod'].pop('invalidationDate')
     self.assertEqual(auction, new_auction)
 
     date_modified_to_patch = (datetime.now() + timedelta(days=30)).isoformat()
@@ -1519,6 +1521,7 @@ def patch_auction(self):
     self.assertEqual(response.content_type, 'application/json')
     new_auction2 = response.json['data']
     new_dateModified2 = new_auction2.pop('dateModified')
+    new_auction2['rectificationPeriod'].pop('invalidationDate')
     self.assertEqual(new_auction, new_auction2)
     self.assertNotEqual(date_modified_to_patch, new_dateModified2)
     # self.assertEqual(new_dateModified, new_dateModified2)

--- a/openprocurement/auctions/appraisal/tests/blanks/tender_blanks.py
+++ b/openprocurement/auctions/appraisal/tests/blanks/tender_blanks.py
@@ -1482,7 +1482,6 @@ def patch_auction(self):
     )
     auction = response.json['data']
     dateModified = auction.pop('dateModified')
-    auction['rectificationPeriod'].pop('invalidationDate')
 
     response = self.app.patch_json('/auctions/{}?acc_token={}'.format(auction['id'], owner_token),
                                    {'data': {'status': 'cancelled'}})
@@ -1510,7 +1509,6 @@ def patch_auction(self):
     self.assertEqual(response.content_type, 'application/json')
     new_auction = response.json['data']
     new_auction.pop('dateModified')
-    new_auction['rectificationPeriod'].pop('invalidationDate')
     self.assertEqual(auction, new_auction)
 
     date_modified_to_patch = (datetime.now() + timedelta(days=30)).isoformat()
@@ -1521,7 +1519,6 @@ def patch_auction(self):
     self.assertEqual(response.content_type, 'application/json')
     new_auction2 = response.json['data']
     new_dateModified2 = new_auction2.pop('dateModified')
-    new_auction2['rectificationPeriod'].pop('invalidationDate')
     self.assertEqual(new_auction, new_auction2)
     self.assertNotEqual(date_modified_to_patch, new_dateModified2)
     # self.assertEqual(new_dateModified, new_dateModified2)

--- a/openprocurement/auctions/appraisal/utils.py
+++ b/openprocurement/auctions/appraisal/utils.py
@@ -98,7 +98,7 @@ def calc_auction_end_time(stages, start):
 
 def invalidate_bids_data(auction):
     rectification_period_exists = auction.rectification_period.endDate is not None
-    rectification_period_not_finished = rectification_period_exists and get_now() < auction.rectification_period.endDate
+    rectification_period_not_finished = rectification_period_exists and get_now() > auction.rectification_period.endDate
     if auction.status == 'active.tendering' and rectification_period_not_finished:
         return
 

--- a/openprocurement/auctions/appraisal/utils.py
+++ b/openprocurement/auctions/appraisal/utils.py
@@ -97,7 +97,9 @@ def calc_auction_end_time(stages, start):
 
 
 def invalidate_bids_data(auction):
-    if auction.status == 'active.tendering' and get_now() > auction.rectificationPeriod.endDate:
+    rectification_period_exists = auction.rectification_period.endDate is not None
+    rectification_period_not_finished = rectification_period_exists and get_now() < auction.rectification_period.endDate
+    if auction.status == 'active.tendering' and rectification_period_not_finished:
         return
 
     for bid in auction['bids']:


### PR DESCRIPTION
Змінити мінімальний період tenderPeriod з 7 днів на 1 день. 

Також під час тестування цієї задачі було виявлено багу: якщо tenderPeriod == мінімальній довжені періоду -> rectificationPeriod не створюється, хоча в 2 місцях була робота з rectificationPeriod.endDate:
`if request.context.status == 'active.tendering' and get_now() < self.rectification_period.endDate`

В результаті була помилка:
> TypeError: can't compare datetime.datetime to NoneType

https://jira-sale.prozorro.org/browse/INFRA-45